### PR TITLE
Jekyll udpate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ source "https://rubygems.org"
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 
-gem "github-pages",group: :jekyll_plugins
+gem "github-pages", group: :jekyll_plugins
 
 # If you want to use Jekyll native, uncomment the line below.
 # To upgrade, run `bundle update`.
 
-gem "jekyll", "=3.9.3"
+gem "jekyll"
 gem "json"
 
 gem "wdm", "~> 0.1.0" if Gem.win_platform?

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -1,6 +1,6 @@
 ---
 title: "Page Not Found"
-excerpt: "Page not found. Your pixels are in another canvas."
+# excerpt: "Page not found. Your pixels are in another canvas."
 sitemap: false
 permalink: /404.html
 ---

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,7 +1,7 @@
 ---
 permalink: /
 title: "Will Jardee's Personal Website"
-excerpt: "Nothing here yet"
+# excerpt: "Nothing here yet"
 author_profile: true
 redirect_from: 
   - /about/

--- a/_pages/to-read.md
+++ b/_pages/to-read.md
@@ -1,7 +1,7 @@
 ---
 permalink: /to-read
 title: "To Read"
-excerpt: "Things I have saved to read later"
+# excerpt: "Things I have saved to read later"
 author_profile: true
 ---
 


### PR DESCRIPTION
Recent Jekyll update leaves conflict with method used for `excerpt_separator`. [https://github.com/academicpages/academicpages.github.io/issues/1878#issuecomment-1936903121](url)